### PR TITLE
ipfs/bootstrap: Extends ipfs nodes for DHT

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -427,7 +427,10 @@ impl Network {
             }
             Network::Ipfs => {
                 vec![
-                    ("/ip4/104.131.131.82/tcp/4001".parse().unwrap(), FromStr::from_str("QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ").unwrap()),
+                    ("/dnsaddr/bootstrap.libp2p.io".parse().unwrap(), FromStr::from_str("QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN").unwrap()),
+                    ("/dnsaddr/bootstrap.libp2p.io".parse().unwrap(), FromStr::from_str("QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa").unwrap()),
+                    ("/dnsaddr/bootstrap.libp2p.io".parse().unwrap(), FromStr::from_str("QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb").unwrap()),
+                    ("/dnsaddr/bootstrap.libp2p.io".parse().unwrap(), FromStr::from_str("QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt").unwrap()),
                 ]
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -427,6 +427,7 @@ impl Network {
             }
             Network::Ipfs => {
                 vec![
+                    ("/ip4/104.131.131.82/tcp/4001".parse().unwrap(), FromStr::from_str("QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ").unwrap()),
                     ("/dnsaddr/bootstrap.libp2p.io".parse().unwrap(), FromStr::from_str("QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN").unwrap()),
                     ("/dnsaddr/bootstrap.libp2p.io".parse().unwrap(), FromStr::from_str("QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa").unwrap()),
                     ("/dnsaddr/bootstrap.libp2p.io".parse().unwrap(), FromStr::from_str("QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb").unwrap()),


### PR DESCRIPTION
This extends the bootstrap nodes for ipfs dht ~~but also removes the existing node due to it being unusable (havent been able to use that node at all in other projects for a few weeks so it may not be any good to use now).~~

Closes #57

EDIT: The node that was removed in this PR looks to have been updated to a rc of ipfs/kubo 0.18 in the last day or two so and looks to be responding to queries so I went on to add it back here, but extending the bootstrap nodes would still be helpful in the event one ever goes down or doesnt respond. 