### PR TITLE
Added support for loading keypair as file used in authentication in direct mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /target
+
+# IntelliJ IDEA
+.idea
+*.iml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
+name = "base58"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,6 +1492,7 @@ version = "0.6.2"
 dependencies = [
  "ansi_term",
  "async-std",
+ "base58",
  "env_logger",
  "futures",
  "libp2p",
@@ -2057,9 +2064,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opaque-debug"
@@ -2141,22 +2148,22 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/mxinden/libp2p-lookup"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libp2p = { git = "https://github.com/libp2p/rust-libp2p", branch = "master", version = "0.51.0", default-features = false, features = ["dns", "async-std", "noise", "tcp", "yamux", "identify", "kad", "ping", "mplex", "relay", "quic", "rsa", "macros", "secp256k1", "ecdsa"] }
+libp2p = { git = "https://github.com/libp2p/rust-libp2p", branch = "master", version = "0.51.3", default-features = false, features = ["dns", "async-std", "noise", "tcp", "yamux", "identify", "kad", "ping", "mplex", "relay", "quic", "rsa", "macros", "secp256k1", "ecdsa"] }
 structopt = "0.3.26"
 futures = "0.3.26"
 env_logger = "0.10.0"
@@ -18,3 +18,4 @@ async-std = { version = "1.12.0", features = ["attributes"] }
 ansi_term = "0.12.1"
 log = "0.4"
 thiserror = "1"
+base58 = "0.2.0"

--- a/README.md
+++ b/README.md
@@ -35,8 +35,43 @@ SUBCOMMANDS:
 
 #### Lookup peer by [address][multiaddr]
 
+Generates random keypair with peer ID and connects to the provided address.
+
 ```
 $ libp2p-lookup direct --address /dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa
+
+Lookup for peer with id PeerId("QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa") succeeded.
+
+Protocol version: "ipfs/0.1.0"
+Agent version: "go-ipfs/0.8.0/48f94e2"
+Observed address: "/ip4/2.200.106.157/tcp/56136"
+Listen addresses:
+        - "/ip4/147.75.77.187/tcp/4001"
+        - "/ip6/2604:1380:0:c100::1/tcp/4001"
+        - "/ip4/147.75.77.187/udp/4001/quic"
+        - "/ip6/2604:1380:0:c100::1/udp/4001/quic"
+Protocols:
+        - "/p2p/id/delta/1.0.0"
+        - "/ipfs/id/1.0.0"
+        - "/ipfs/id/push/1.0.0"
+        - "/ipfs/ping/1.0.0"
+        - "/libp2p/circuit/relay/0.1.0"
+        - "/ipfs/kad/1.0.0"
+        - "/ipfs/lan/kad/1.0.0"
+        - "/libp2p/autonat/1.0.0"
+        - "/ipfs/bitswap/1.2.0"
+        - "/ipfs/bitswap/1.1.0"
+        - "/ipfs/bitswap/1.0.0"
+        - "/ipfs/bitswap"
+        - "/x/"
+```
+
+#### Lookup peer by [address][multiaddr] and keypair file
+
+If your network nodes only allow certain PeerId's to connect, then you can provide your own keypair file (base58 encoded) to authenticate with the node.
+
+```
+$ libp2p-lookup direct --address /dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa --keypair-path ./path/to/keypair.base58
 
 Lookup for peer with id PeerId("QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa") succeeded.
 


### PR DESCRIPTION
There is a need to have ability to load existing keypair file used for authentication with P2P nodes which only allow known PeerIds to connect (https://docs.rs/libp2p/latest/libp2p/allow_block_list/index.html#structs). 

Proposed change adds additional parameter in "direct" mode to load keypair from given file path. 
This only applies to direct mode connecting to a given node which requires authentication with "whitelisted" PeerId.
Currently it only supports base58 encoded files.

Example:
`libp2p-lookup direct --address /dns/node-1/tcp/55123 --keypair-path ~/path/to/key.base58`
